### PR TITLE
Add `"incorrect-dictionary-iterator"` to checked messages

### DIFF
--- a/perflint/checker.py
+++ b/perflint/checker.py
@@ -28,7 +28,7 @@ class ForLoopChecker(BaseChecker):
         )
     }
 
-    @checker_utils.check_messages("unnecessary-list-cast")
+    @checker_utils.check_messages("unnecessary-list-cast", "incorrect-dictionary-iterator")
     def visit_for(self, node: nodes.For) -> None:
         """Visit for loops."""
         if not node.iter:


### PR DESCRIPTION
Source: https://github.com/PyCQA/pylint/blob/c0fbbb7adbc39cbd67bbd0e0b1ca4e9421c12643/pylint/utils/ast_walker.py#L19-L22