### PR TITLE
Update references to `loop-invariant-global-usage`

### DIFF
--- a/perflint/for_loop_checker.py
+++ b/perflint/for_loop_checker.py
@@ -303,7 +303,7 @@ class LoopInvariantChecker(BaseChecker):
         if isinstance(node.target, nodes.AssignName):
             self._loop_assignments[-1].add(node.target.name)
 
-    @checker_utils.check_messages("loop-invariant-global-usage")
+    @checker_utils.check_messages("loop-global-usage")
     def visit_name(self, node: nodes.Name) -> None:
         """Look for global names"""
         if self._loop_names:
@@ -321,7 +321,7 @@ class LoopInvariantChecker(BaseChecker):
             and isinstance(scope.globals[node.name][0], nodes.AssignName)
         ):
             if self._loop_level > 0:
-                self.add_message("loop-invariant-global-usage", node=node)
+                self.add_message("loop-global-usage", node=node)
 
     def visit_const(self, node: nodes.Const) -> None:
         if self._loop_level == 0:

--- a/tests/test_loop_invariant.py
+++ b/tests/test_loop_invariant.py
@@ -95,7 +95,7 @@ class TestUniqueReturnChecker(BaseCheckerTestCase):
         """
         )
 
-        with self.assertAddedMessage("loop-invariant-global-usage"):
+        with self.assertAddedMessage("loop-global-usage"):
             self.walk(test_func)
 
     def test_assigned_global_in_for_loop(self):


### PR DESCRIPTION
Looks like these were missed as part of #27

Was seeing the following error while re-testing #26 at [4bf47e0](https://github.com/tonybaloney/perflint/commit/4bf47e0588990342234fcdcef5248f1aed6336b9)
```
$ perflint repro.py
Exception on node <Name.x l.5 at 0x10efcae90> in file '/tmp/repro.py'
Traceback (most recent call last):
  File "/tmp/venv-710/lib/python3.10/site-packages/pylint/utils/ast_walker.py", line 73, in walk
    callback(astroid)
  File "/tmp/venv-710/lib/python3.10/site-packages/perflint/for_loop_checker.py", line 324, in visit_name
    self.add_message("loop-invariant-global-usage", node=node)
  File "/tmp/venv-710/lib/python3.10/site-packages/pylint/checkers/base_checker.py", line 112, in add_message
    self.linter.add_message(
  File "/tmp/venv-710/lib/python3.10/site-packages/pylint/lint/pylinter.py", line 1629, in add_message
    message_definitions = self.msgs_store.get_message_definitions(msgid)
  File "/tmp/venv-710/lib/python3.10/site-packages/pylint/message/message_definition_store.py", line 65, in get_message_definitions
    for m in self.message_id_store.get_active_msgids(msgid_or_symbol)
  File "/tmp/venv-710/lib/python3.10/site-packages/pylint/message/message_id_store.py", line 130, in get_active_msgids
    raise UnknownMessageError(error_msg)
pylint.exceptions.UnknownMessageError: No such message id or symbol 'loop-invariant-global-usage'.
```