### PR TITLE
Fix deprecation warning

### DIFF
--- a/perflint/comprehension_checker.py
+++ b/perflint/comprehension_checker.py
@@ -1,7 +1,7 @@
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers import utils as checker_utils
-from astroid.helpers import safe_infer
+from astroid.util import safe_infer
 
 
 class ComprehensionChecker(BaseChecker):

--- a/perflint/for_loop_checker.py
+++ b/perflint/for_loop_checker.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Set, Union
 from astroid import nodes
-from astroid.helpers import safe_infer
+from astroid.util import safe_infer
 from pylint.checkers import BaseChecker
 from pylint.checkers import utils as checker_utils
 from pylint.interfaces import INFERENCE


### PR DESCRIPTION
`safe_infer` was moved to `astroid.util` in [3.0.0](https://pylint.readthedocs.io/projects/astroid/en/latest/changelog.html#what-s-new-in-astroid-3-0-0) and importing it from `helpers` [issues](https://github.com/tonybaloney/perflint/actions/runs/7480392483/job/20359711707#step:5:20) a deprecation warning:

> /opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/site-packages/perflint/comprehension_checker.py:78: DeprecationWarning: Import safe_infer from astroid.util; this shim in astroid.helpers will be removed.
