### PR TITLE
Add rule to check for eager log message string formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,3 +315,31 @@ def should_be_a_dict_comprehension_filtered():
         if y % 2:
             result[x] = y
 ```
+
+### W8501 : Delegate message string formatting to the logger (`use-logger-formatting`)
+
+Log message string formatting should be delegated to the logging framework. This way the string formatting will not be performed if the particular logging level is not enabled.
+
+```python
+import logging
+import time
+
+class Foo:
+    def __init__(self, value: int):
+        self.value = value
+
+    def __str__(self):
+        print(f"Calling Foo expensive __str__ on Foo with value {self.value}")
+        time.sleep(0.25)
+        return f"My value is: {self.value}"
+
+def eager_formatting():
+    foo = Foo(1)
+    # Expensive Foo.__str__ will be called even though logging.DEBUG level is not enabled.
+    logging.debug("The value of `foo` is %s" % foo)
+
+def lazy_formatting():
+    foo = Foo(1)
+    # Expensive Foo.__str__ will not be called since logging.DEBUG level is not enabled.
+    logging.debug("The value of `foo` is %s", foo)
+```

--- a/perflint/__init__.py
+++ b/perflint/__init__.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from perflint.for_loop_checker import ForLoopChecker, LoopInvariantChecker
 from perflint.list_checker import ListChecker
 from perflint.comprehension_checker import ComprehensionChecker
+from perflint.logging_checker import LoggingChecker
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
@@ -21,3 +22,4 @@ def register(linter: "PyLinter") -> None:
     linter.register_checker(LoopInvariantChecker(linter))
     linter.register_checker(ListChecker(linter))
     linter.register_checker(ComprehensionChecker(linter))
+    linter.register_checker(LoggingChecker(linter))

--- a/perflint/__main__.py
+++ b/perflint/__main__.py
@@ -5,6 +5,7 @@ import sys
 from perflint.for_loop_checker import ForLoopChecker, LoopInvariantChecker
 from perflint.list_checker import ListChecker
 from perflint.comprehension_checker import ComprehensionChecker
+from perflint.logging_checker import LoggingChecker
 
 
 pylint.modify_sys_path()
@@ -14,6 +15,7 @@ rules = (
     + list(LoopInvariantChecker.msgs.keys())
     + list(ListChecker.msgs.keys())
     + list(ComprehensionChecker.msgs.keys())
+    + list(LoggingChecker.msgs.keys())
 )
 
 args = []

--- a/perflint/logging_checker.py
+++ b/perflint/logging_checker.py
@@ -1,0 +1,141 @@
+from astroid import nodes
+from astroid.bases import Instance
+from pylint.checkers import BaseChecker
+from pylint.checkers import utils as checker_utils
+
+
+def _is_string_concat(node: nodes.NodeNG) -> bool:
+    """Return True if `node` is a string concatenation.
+
+    E.g. `"a" + [... +] "z"`.
+    """
+    if not (isinstance(node, nodes.BinOp) and node.op == "+"):
+        return False
+
+    return _is_string(node.left) and _is_string(node.right)
+
+
+def _is_string(node: nodes.NodeNG) -> bool:
+    """Return True if `node` is a string literal/f-string/concatenated string."""
+    return (
+        (isinstance(node, nodes.Const) and isinstance(node.value, str))
+        or isinstance(node, nodes.JoinedStr)
+        or _is_string_concat(node)
+    )
+
+
+def _is_old_style_formatted_string(node: nodes.NodeNG) -> bool:
+    """Return True if `node` is an old-style formatted string.
+    
+    E.g. `"%s" % value`."""
+    return isinstance(node, nodes.BinOp) and node.op == "%"
+
+
+def _is_new_style_formatted_string(node: nodes.NodeNG) -> bool:
+    """Return True if `node` is a new-style formatted string.
+
+    E.g. `"foo: {}".format(foo))` or `"foo: {bar}".format_map({"bar": 1})`.
+    """
+    return (
+        isinstance(node, nodes.Call)
+        and isinstance(node.func, nodes.Attribute)
+        and node.func.attrname in ("format", "format_map")
+        and _is_string(node.func.expr)
+    )
+
+
+def _is_fstring(node: nodes.NodeNG) -> bool:
+    """Return True if `node` is an f-string with at least one placeholder.
+
+    E.g. `f"foo: {foo}"`.
+    """
+    return isinstance(node, nodes.JoinedStr) and any(
+        isinstance(v, nodes.FormattedValue) for v in node.values
+    )
+
+
+def _is_string_and_var_concat(node: nodes.NodeNG) -> bool:
+    """Return True if `node` is a concatenation of a string literal and a
+       variable/attribute.
+
+    E.g.: `"foo: " + string_var_or_attr [+ ...]`.
+    """
+    if not (isinstance(node, nodes.BinOp) and node.op == "+"):
+        return False
+
+    if _is_string(node.left):
+        return isinstance(
+            node.right, (nodes.Name, nodes.Attribute)
+        ) or _is_string_and_var_concat(node.right)
+    elif _is_string(node.right):
+        return isinstance(
+            node.left, (nodes.Name, nodes.Attribute)
+        ) or _is_string_and_var_concat(node.left)
+
+    return False
+
+
+class LoggingChecker(BaseChecker):
+    """
+    Check for already formatted strings being passed to logger methods
+    """
+
+    name = "logging-checker"
+    msgs = {
+        "W8501": (
+            "Delegate message string formatting to the logger",
+            "use-logger-formatting",
+            "String formatting done by the logger is lazy, i.e. "
+            "it will not be performed if the logger level is not enabled.",
+        ),
+    }
+
+    @checker_utils.only_required_for_messages("logging-checker")
+    def visit_call(self, node: nodes.Call):
+        # It is a call to a logging method.
+        if not isinstance(node.func, nodes.Attribute):
+            return
+        func_name = node.func.attrname
+        if func_name not in (
+            "debug",
+            "info",
+            "warning",
+            "warn",
+            "error",
+            "exception",
+            "critical",
+            "fatal",
+            "log",
+        ):
+            return
+
+        # The method call is on a logger or on the `logging` module.
+        if not any(
+            (
+                # log.info
+                (
+                    isinstance(expr_type, Instance)
+                    and expr_type.pytype() in ("logging.Logger", "logging.RootLogger")
+                )
+                or
+                # logging.info
+                (isinstance(expr_type, nodes.Module) and expr_type.name == "logging")
+            )
+            for expr_type in node.func.expr.infer()
+        ):
+            return
+
+        # .info(message) or .log(level, message)
+        nargs = 2 if func_name == "log" else 1
+        # If there are more than `nargs` arguments then formatting is left to the logger.
+        if len(node.args) != nargs:
+            return
+
+        last_arg = node.args[nargs - 1]
+        if (
+            _is_old_style_formatted_string(last_arg)
+            or _is_new_style_formatted_string(last_arg)
+            or _is_fstring(last_arg)
+            or _is_string_and_var_concat(last_arg)
+        ):
+            self.add_message("use-logger-formatting", node=last_arg)

--- a/tests/functional/logging_formatting.py
+++ b/tests/functional/logging_formatting.py
@@ -1,0 +1,18 @@
+import logging
+import time
+
+
+class Foo:
+    def __init__(self, value: int):
+        self.value = value
+
+    def __str__(self):
+        print(f"Calling Foo expensive __str__ on Foo with value {self.value}")
+        time.sleep(0.25)
+        return f"My value is: {self.value}"
+
+
+def example_eager_formatting():
+    foo = Foo(1)
+    # Expensive Foo.__str__ will be called even though logging.DEBUG level is not enabled.
+    logging.debug("The value of `foo` is %s" % foo)

--- a/tests/test_logging_checker.py
+++ b/tests/test_logging_checker.py
@@ -1,0 +1,269 @@
+import astroid
+import perflint.logging_checker
+
+from base import BaseCheckerTestCase
+
+
+class TestLoggingChecker(BaseCheckerTestCase):
+    CHECKER_CLASS = perflint.logging_checker.LoggingChecker
+
+    def test_message_is_old_style_formatted_string(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            logger.info("The number is %d" % 1)
+        """)
+
+        with self.assertAddedMessage("use-logger-formatting"):
+            self.walk(test_func)
+
+    def test_message_is_old_style_formatted_string_w_multiple_values(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            logger.info("The number is %d, the string is: %s" % (1, "bar"))
+        """)
+
+        with self.assertAddedMessage("use-logger-formatting"):
+            self.walk(test_func)
+
+    def test_message_is_old_style_formatted_string_w_dict(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            logger.info(
+                "The number %(foo)d, the string is: %(string)s" % {
+                    "number": 1,
+                    "string": "bar",
+                },
+            )
+        """)
+
+        with self.assertAddedMessage("use-logger-formatting"):
+            self.walk(test_func)
+
+    def test_message_is_old_style_formatted_fstring(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            foo = 1
+            logger.info(f"The value of `foo` is {foo}, `bar` is %d" % 2)
+        """)
+
+        with self.assertAddedMessage("use-logger-formatting"):
+            self.walk(test_func)
+
+    def test_message_is_string_and_variable_concatenation(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            foo = "Foo"
+            logger.info("The value of `foo` is " + foo)
+        """)
+
+        with self.assertAddedMessage("use-logger-formatting"):
+            self.walk(test_func)
+
+    def test_message_is_string_and_variable_concatenation_in_the_middle(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            foo = "Foo"
+            logger.info("The value of `foo` is " + foo + ".")
+        """)
+
+        with self.assertAddedMessage("use-logger-formatting"):
+            self.walk(test_func)
+
+    def test_message_is_string_and_attribute_concatenation(self):
+        test_func = astroid.extract_node("""
+        import logging
+        import os
+        logger = logging.getLogger(__name__)
+
+        def test():
+            logger.info("Current OS is " + os.name)
+        """)
+
+        with self.assertAddedMessage("use-logger-formatting"):
+            self.walk(test_func)
+
+    def test_message_is_variable_and_string_concatenation(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            foo = "Foo"
+            logger.info(foo + " is the value of `foo`")
+        """)
+
+        with self.assertAddedMessage("use-logger-formatting"):
+            self.walk(test_func)
+
+    def test_message_is_string_concatenation_is_ignored(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            logger.info("Using " + "string concatenation")
+        """)
+
+        with self.assertNoMessages():
+            self.walk(test_func)
+
+    def test_message_is_adjacent_string_concatenation_is_ignored(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            logger.info("Using " "adjacent string concatenation")
+        """)
+
+        with self.assertNoMessages():
+            self.walk(test_func)
+
+    def test_message_is_parenthesized_string_concatenation_is_ignored(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            logger.info(("Using ") + ("parenthesized string concatenation"))
+        """)
+
+        with self.assertNoMessages():
+            self.walk(test_func)
+
+    def test_message_is_new_style_formatted_string(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            logger.info("The value of `foo` is {}".format(1))
+        """)
+
+        with self.assertAddedMessage("use-logger-formatting"):
+            self.walk(test_func)
+
+    def test_message_is_new_style_formatted_string_with_format_map(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            logger.info("The value of `foo` is {foo}".format_map({"foo": 1}))
+        """)
+
+    def test_message_is_new_style_formatted_fstring(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            foo = 1
+            logger.info(f"The value of `foo` is {foo}, `bar` is {{bar}}".format_map({"bar": w}))
+        """)
+
+        with self.assertAddedMessage("use-logger-formatting"):
+            self.walk(test_func)
+
+    def test_message_is_fstring(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            foo = 1
+            logger.info(f"The value of `foo` is {foo}")
+        """)
+
+        with self.assertAddedMessage("use-logger-formatting"):
+            self.walk(test_func)
+
+    def test_message_is_fstring_wo_placeholders_is_ignored(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            logger.info(f"This f-string contains no placeholders")
+        """)
+
+        with self.assertNoMessages():
+            self.walk(test_func)
+
+    def test_message_is_old_style_formatted_string_w_log_method(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            logger.log(logging.INFO, "The value of `foo` is %d" % 1)
+        """)
+
+        with self.assertAddedMessage("use-logger-formatting"):
+            self.walk(test_func)
+
+    def test_message_is_old_style_formatted_string_w_module_function(self):
+        test_func = astroid.extract_node("""
+        import logging
+
+        def test():
+            logging.info("The value of `foo` is %d" % 1)
+        """)
+
+        with self.assertAddedMessage("use-logger-formatting"):
+            self.walk(test_func)
+
+    def test_formatting_left_to_logger_is_ignored(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            logger.info("The value of `foo` is %d", 1)
+        """)
+
+        with self.assertNoMessages():
+            self.walk(test_func)
+
+    def test_static_message_string_is_ignored(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            logger.info("This message does not use formatting")
+        """)
+
+        with self.assertNoMessages():
+            self.walk(test_func)
+
+    def test_message_string_var_is_ignored(self):
+        test_func = astroid.extract_node("""
+        import logging
+        logger = logging.getLogger(__name__)
+
+        def test():
+            message = "This message does not use formatting"
+            logger.info(message)
+        """)
+
+        with self.assertNoMessages():
+            self.walk(test_func)


### PR DESCRIPTION
Log message string formatting should be delegated to the logging framework. This way the string formatting will not be performed if the particular logging level is not enabled.

```python
import logging
import time

class Foo:
    def __init__(self, value: int):
        self.value = value

    def __str__(self):
        print(f"Calling Foo expensive __str__ on Foo with value {self.value}")
        time.sleep(0.25)
        return f"My value is: {self.value}"

def eager_formatting():
    foo = Foo(1)
    # Expensive Foo.__str__ will be called even though logging.DEBUG level is not enabled.
    logging.debug("The value of `foo` is %s" % foo)

def lazy_formatting():
    foo = Foo(1)
    # Expensive Foo.__str__ will not be called since logging.DEBUG level is not enabled.
    logging.debug("The value of `foo` is %s", foo)
```
