### PR TITLE
Drop checker priority

### DIFF
--- a/perflint/comprehension_checker.py
+++ b/perflint/comprehension_checker.py
@@ -10,7 +10,6 @@ class ComprehensionChecker(BaseChecker):
     """
 
     name = "comprehension-checker"
-    priority = -1
     msgs = {
         "W8401": (
             "Use a list comprehension instead of a for-loop",

--- a/perflint/for_loop_checker.py
+++ b/perflint/for_loop_checker.py
@@ -54,7 +54,6 @@ class ForLoopChecker(BaseChecker):
     """
 
     name = "for-loop-checker"
-    priority = -1
     msgs = {
         "W8101": (
             "Unnecessary using of list() on an already iterable type.",
@@ -130,7 +129,6 @@ class LoopInvariantChecker(BaseChecker):
     """
 
     name = "loop-invariant-checker"
-    priority = -1
     msgs = {
         "W8201": (
             "Consider moving this expression outside of the loop.",

--- a/perflint/list_checker.py
+++ b/perflint/list_checker.py
@@ -10,7 +10,6 @@ class ListChecker(BaseChecker):
     """
 
     name = 'list-checker'
-    priority = -1
     msgs = {
         'W8301': (
             'Use tuple instead of list for a non-mutated sequence',


### PR DESCRIPTION
The concept of checker priority was removed[1] in Pylint 2.14.0[2].

[1]: https://github.com/pylint-dev/pylint/commit/e01fa86c00b2cd879c44570b383115a9407547f1
[2]: https://pylint.readthedocs.io/en/v3.0.3/whatsnew/2/2.14/full.html#what-s-new-in-pylint-2-14-0