### PR TITLE
Ignore calls to non-mutating list methods

### DIFF
--- a/perflint/list_checker.py
+++ b/perflint/list_checker.py
@@ -58,7 +58,9 @@ class ListChecker(BaseChecker):
             return
         if not isinstance(node.func.expr, nodes.Name):
             return
-        # TODO : Filter from non-mutation methods
+        # Ignore calls to non-mutating methods.
+        if node.func.attrname in ("copy", "count", "index"):
+            return
         self._mark_mutated(node.func.expr)
 
     def _mark_mutated(self, _name: nodes.Name):

--- a/tests/test_list_checker.py
+++ b/tests/test_list_checker.py
@@ -16,6 +16,16 @@ class TestListMutationChecker(BaseCheckerTestCase):
         with self.assertAddedMessage("use-tuple-over-list"):
             self.walk(test_func)
 
+    def test_non_mutating_method_call_on_list_should_be_tuple(self):
+        test_func = astroid.extract_node("""
+        def test():
+            items = [1,2,3,4]
+            items.count(1)
+        """)
+
+        with self.assertAddedMessage("use-tuple-over-list"):
+            self.walk(test_func)
+
     def test_const_all_be_ignored(self):
         test_func = astroid.extract_node("""
         def test(): #@


### PR DESCRIPTION
This allows to avoid false-negatives when a non-mutating method is called on a list.