### PR TITLE
Detect list being mutated by `del` statement

### DIFF
--- a/perflint/list_checker.py
+++ b/perflint/list_checker.py
@@ -73,7 +73,7 @@ class ListChecker(BaseChecker):
             del self._lists_to_watch[0][_name.name]
 
     def visit_subscript(self, node: nodes.Subscript):
-        if not isinstance(node.parent, nodes.Assign):
+        if not isinstance(node.parent, (nodes.Assign, nodes.Delete)):
             return
         if not isinstance(node.value, nodes.Name):
             return

--- a/tests/test_list_checker.py
+++ b/tests/test_list_checker.py
@@ -45,6 +45,16 @@ class TestListMutationChecker(BaseCheckerTestCase):
         with self.assertNoMessages():
             self.walk(test_func)
 
+    def test_mutated_list_by_del(self):
+        test_func = astroid.extract_node("""
+        def test():
+            items = [1,2,3,4]
+            del items[0]
+        """)
+
+        with self.assertNoMessages():
+            self.walk(test_func)
+
     def test_mutated_global_list_by_index(self):
         test_func = astroid.extract_node("""
         items = [1,2,3,4]
@@ -60,6 +70,16 @@ class TestListMutationChecker(BaseCheckerTestCase):
         items = [1,2,3,4]
         def test(): #@
             items.append(5)
+        """)
+
+        with self.assertNoMessages():
+            self.walk(test_func)
+
+    def test_mutated_global_list_by_del(self):
+        test_func = astroid.extract_node("""
+        items = [1,2,3,4]
+        def test():
+            del items[0]
         """)
 
         with self.assertNoMessages():


### PR DESCRIPTION
Avoid `use-tuple-over-list` false positives when a list is being mutated by a `del` statement.